### PR TITLE
btm: Fix compile with BLE disabled (again)

### DIFF
--- a/stack/btm/btm_acl.c
+++ b/stack/btm/btm_acl.c
@@ -1026,7 +1026,9 @@ void btm_read_remote_version_complete (UINT8 *p)
                              p_acl_cb->remote_addr[3], p_acl_cb->remote_addr[4], p_acl_cb->remote_addr[5]);
                 BTM_TRACE_WARNING ("btm_read_remote_version_complete lmp_version %d manufacturer %d lmp_subversion %d",
                                         p_acl_cb->lmp_version,p_acl_cb->manufacturer, p_acl_cb->lmp_subversion);
+#if BLE_INCLUDED == TRUE
                 if (p_acl_cb->transport == BT_TRANSPORT_BR_EDR)
+#endif
                     btm_read_remote_features (p_acl_cb->hci_handle);
             }
 


### PR DESCRIPTION
- Broken in d4cd18182d0868a1018436f8e917f5580abdc1fa

Change-Id: If56e31914e8e9742e720c35ac3ec449aafdb3142
