### PR TITLE
l2cap: ifdef checks for BLE_INCLUDED

### DIFF
--- a/stack/l2cap/l2c_link.c
+++ b/stack/l2cap/l2c_link.c
@@ -942,7 +942,11 @@ void l2c_link_adjust_allocation (void)
     /* Now, assign the quotas to each link */
     for (yy = 0, p_lcb = &l2cb.lcb_pool[0]; yy < MAX_L2CAP_LINKS; yy++, p_lcb++)
     {
-        if (p_lcb->in_use && p_lcb->transport == BT_TRANSPORT_BR_EDR)
+        if (p_lcb->in_use
+#if (BLE_INCLUDED == TRUE)
+                && p_lcb->transport == BT_TRANSPORT_BR_EDR
+#endif
+                )
         {
             if (p_lcb->acl_priority == L2CAP_PRIORITY_HIGH)
             {


### PR DESCRIPTION
Transport is checked in code even when BLE_INCLUDED = FALSE.

Change-Id: I6eaaad1242e943835b6e040687562801451cfc2a
